### PR TITLE
TCP Benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DASH-NS3
 A simulation model for HTTP-based adaptive streaming applications
 
-If you use the model, please reference "Simulation Framework for HTTP-Based Adaptive Streaming Applications" by Harald Ott, Konstantin Miller, and Adam Wolisz, 2017
+This model is an extension of "Simulation Framework for HTTP-Based Adaptive Streaming Applications" by Harald Ott, Konstantin Miller, and Adam Wolisz, 2017.
 
 ## NEEDED FILES
 Just drop the repository into the contrib/ folder of ns-3 (only works with ns version between 3.27 and 3.30)
@@ -13,22 +13,31 @@ Since I've already received a lot of questions about errors that arise from this
 Its name needs to remain 'dash'
 
 ## PROGRAM EXECUTION
-The following parameters have to be specified for program execution:
-- simulationId: The Id of this simulation, to distinguish it from others, with same algorithm and number of clients, for logging purposes.
-- numberOfClients: The number of streaming clients used for this simulation.
-- segmentDuration: The duration of a segment in microseconds.
-- adaptationAlgo: The name of the adaptation algorithm the client uses for the simulation. The 'pre-installed' algorithms are tobasco, festive and panda.
-- segmentSizeFile: The relative path (from the ns-3.x/ folder) of the file containing the sizes of the segments of the video. The segment sizes have to be provided as a (n, m) matrix, with n being the number of representation levels and m being the total number of segments. A two-segment long, three representations containing segment size file would look like the following:
+There are two runnable scripts available: 
+* `tcp-stream` - written by the framework's original authors as part of their paper. See the full text for details.
+* `simple-tcp-streaming` - written by J. Kirkwin as a benchmarking tool for further work.
+
+The following parameters must be defined for either one:
+- `simulationId`: The Id of this simulation for logging purposes.
+- `segmentDuration`: The duration of a segment in microseconds.
+- `adaptationAlgo`: The name of the adaptation algorithm the client uses for the simulation. The 'pre-installed' algorithms are tobasco, festive and panda.
+- `segmentSizeFile`: The relative path (from the ns-3.x/ folder) of the file containing the sizes of the segments of the video. The segment sizes have to be provided as a (n, m) matrix, with n being the number of representation levels and m being the total number of segments. A two-segment long, three representations containing segment size file would look like the following:
 
  1564 22394  
  1627 46529  
  1987 121606  
 
-One possible execution of the program would be:
+`tcp-stream` also requires the `numberOfClients` parameter.
+
+One possible execution of the original program would be:
 ```bash
 ./waf --run="tcp-stream --simulationId=1 --numberOfClients=3 --adaptationAlgo=panda --segmentDuration=2000000 --segmentSizeFile=contrib/dash/segmentSizes.txt"
 ```
 
+One possible execution of the benchmarking program would be:
+```bash
+./waf --run="simple-tcp-streaming --simulationId=2 --adaptationAlgo=festive --segmentDuration=2000000 --segmentSizeFile=contrib/dash/segmentSizes.txt"
+```
 
 ## ADDING NEW ADAPTATION ALGORITHMS
 The adaptation algorithm base class is located in src/applications/model/adaptation-algorithm/. If it is desired to implement a new adaptation algorithm, a separate source and header file for the algorithm can be created in the adaptation-algorithm/ folder. An example of how a header file looks like can be seen here:
@@ -98,4 +107,7 @@ else
 ```
 Lastly, the header file of the newly implemented adaptation algorithm needs to be included in the TcpStreamClient header file.
 
-The resulting logfiles will be written to mylogs/algorithmName/numberOfClients/
+## LOGGING
+
+The client logs QoS and playback information in a set of log files in the folder `dash-log-files/<algorithm name>/<simulation ID>`. 
+For example, the logs for a test-run of a simulation with id 2 using the tobasco algorithm would be stored in `dash-log-files/tobasco/2/`. 

--- a/examples/simple-tcp-streaming.cc
+++ b/examples/simple-tcp-streaming.cc
@@ -1,0 +1,136 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+// This is a simple DASH streaming demo over TCP.
+// The simulation consists of a single client and a single server with 
+// a point-to-point link between them.
+//
+//  n1 (client)                 n2 (server)
+//   |                           |
+//   +---------------------------+
+//    point-to-point connection
+
+
+#include <fstream>
+#include <sys/stat.h>
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+#include "ns3/internet-module.h"
+#include "ns3/point-to-point-module.h"
+#include "ns3/applications-module.h"
+#include "ns3/tcp-stream-helper.h"
+#include "ns3/tcp-stream-interface.h"
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE ("SimpleTcpStreaming");
+
+// Create folder for client log files
+void
+createLoggingFolder(const std::string& adaptationAlgo, int simulationId) { 
+  const char * mylogsDir = dashLogDirectory.c_str();
+  mkdir (mylogsDir, 0775);
+
+  std::string algodirstr (dashLogDirectory + adaptationAlgo);  
+  const char * algodir = algodirstr.c_str();
+  mkdir (algodir, 0775);
+  
+  std::string dirstr (algodirstr + "/" + std::to_string(simulationId) + "/");
+  const char * dir = dirstr.c_str();
+  mkdir(dir, 0775);
+}
+
+int
+main (int argc, char *argv[])
+{
+  // Enable logging
+  LogComponentEnable ("SimpleTcpStreaming", LOG_LEVEL_INFO);
+  LogComponentEnable ("TcpStreamClientApplication", LOG_LEVEL_INFO);
+  LogComponentEnable ("TcpStreamServerApplication", LOG_LEVEL_INFO);
+
+  // Command-line parameters
+  uint64_t segmentDuration;
+  uint32_t simulationId;
+  std::string adaptationAlgo;
+  std::string segmentSizeFilePath;
+
+  CommandLine cmd;
+  cmd.Usage ("Simulation of streaming with DASH over TCP.\n");
+  cmd.AddValue ("simulationId", "The simulation's index (for logging purposes)", simulationId);
+  cmd.AddValue ("segmentDuration", "The duration of a video segment in microseconds", segmentDuration);
+  cmd.AddValue ("adaptationAlgo", "The adaptation algorithm that the client uses for the simulation", adaptationAlgo);
+  cmd.AddValue ("segmentSizeFile", "The relative path (from ns-3.x directory) to the file containing the segment sizes in bytes", segmentSizeFilePath);
+  cmd.Parse (argc, argv);
+
+  createLoggingFolder(adaptationAlgo, simulationId);
+
+  Config::SetDefault("ns3::TcpSocket::SegmentSize", UintegerValue (1446));
+  Config::SetDefault("ns3::TcpSocket::SndBufSize", UintegerValue (524288));
+  Config::SetDefault("ns3::TcpSocket::RcvBufSize", UintegerValue (524288));
+
+  Time::SetResolution (Time::NS);
+
+  // Two nodes, one for client and one for server
+  NodeContainer nodes;
+  nodes.Create (2);
+
+  // A single p2p connection exists between the client and server
+  PointToPointHelper pointToPoint;
+  pointToPoint.SetDeviceAttribute ("DataRate", StringValue ("5Mbps")); // Arbitrary; can be changed later.
+  pointToPoint.SetChannelAttribute ("Delay", StringValue ("2ms")); // Arbitrary; can be changed later.
+
+  NetDeviceContainer netDevices;
+  netDevices = pointToPoint.Install (nodes);
+
+  std::cout << netDevices.GetN() << " net devices" << std::endl;
+
+  InternetStackHelper stack;
+  stack.Install (nodes);
+
+  Ipv4AddressHelper address;
+  address.SetBase ("10.1.1.0", "255.255.255.0");
+
+  Ipv4InterfaceContainer interfaces = address.Assign (netDevices);
+
+  // Set up the streaming server
+  uint16_t serverPort {80};
+  TcpStreamServerHelper serverHelper (serverPort);
+
+  auto serverNode = nodes.Get(1);
+  ApplicationContainer serverApp = serverHelper.Install (serverNode);
+  serverApp.Start (Seconds (1.0));
+
+  // Set up streaming client
+  auto serverAddress = interfaces.GetAddress(1);
+  TcpStreamClientHelper clientHelper (serverAddress, serverPort);
+
+  clientHelper.SetAttribute ("SegmentDuration", UintegerValue (segmentDuration));
+  clientHelper.SetAttribute ("SegmentSizeFilePath", StringValue (segmentSizeFilePath));
+  clientHelper.SetAttribute ("NumberOfClients", UintegerValue (1));
+  clientHelper.SetAttribute ("SimulationId", UintegerValue (simulationId));
+
+  auto clientNode = nodes.Get(0);
+  std::pair<Ptr<Node>, std::string> clientAlgoPair {clientNode, adaptationAlgo};
+  ApplicationContainer clientApps = clientHelper.Install ({clientAlgoPair});
+  clientApps.Get(0)->SetStartTime(Seconds(2)); // Only have one client application to start 
+
+  NS_LOG_INFO ("Run Simulation. (" << "id: " << simulationId << ")");
+  Simulator::Run ();
+  Simulator::Destroy ();
+  NS_LOG_INFO ("Simulation Complete.");
+
+  return 0;
+}

--- a/examples/tcp-stream.cc
+++ b/examples/tcp-stream.cc
@@ -229,12 +229,12 @@ main (int argc, char *argv[])
   std::string algodirstr (dashLogDirectory +  adaptationAlgo );  
   const char * algodir = algodirstr.c_str();
   mkdir (algodir, 0775);
-  std::string dirstr (dashLogDirectory + adaptationAlgo + "/" + ToString (numberOfClients) + "/");
+  std::string dirstr (dashLogDirectory + adaptationAlgo + "/" + ToString (simulationId) + "/");
   const char * dir = dirstr.c_str();
   mkdir(dir, 0775);
 
   std::ofstream clientPosLog;
-  std::string clientPos = dashLogDirectory + "/" + adaptationAlgo + "/" + ToString (numberOfClients) + "/" + "sim" + ToString (simulationId) + "_"  + "clientPos.txt";
+  std::string clientPos = dirstr + "sim" + ToString (simulationId) + "_"  + "clientPos.txt";
   clientPosLog.open (clientPos.c_str());
   NS_ASSERT_MSG (clientPosLog.is_open(), "Couldn't open clientPosLog file");
 

--- a/examples/wscript
+++ b/examples/wscript
@@ -3,3 +3,6 @@
 def build(bld):
     obj = bld.create_ns3_program('tcp-stream', ['dash', 'internet', 'wifi', 'buildings', 'applications', 'point-to-point'])
     obj.source = 'tcp-stream.cc'
+
+    obj = bld.create_ns3_program('simple-tcp-streaming', ['core', 'dash', 'internet', 'applications', 'point-to-point'])
+    obj.source = 'simple-tcp-streaming.cc'

--- a/model/tcp-stream-client.cc
+++ b/model/tcp-stream-client.cc
@@ -597,37 +597,41 @@ TcpStreamClient::LogPlayback ()
   playbackLog.flush ();
 }
 
+std::string 
+TcpStreamClient::LogFileName(const std::string& simId, const std::string& clientId, const std::string& logSuffix) {
+  return dashLogDirectory + m_algoName + "/" + simId + "/" "cl" + clientId + "_"  + logSuffix + ".txt";
+}
+
 void
 TcpStreamClient::InitializeLogFiles (std::string simulationId, std::string clientId, std::string numberOfClients)
 {
   NS_LOG_FUNCTION (this);
-
-  std::string dLog = dashLogDirectory + m_algoName + "/" +  numberOfClients  + "/sim" + simulationId + "_" + "cl" + clientId + "_"  + "downloadLog.txt";
+  std::string dLog = LogFileName(simulationId, clientId, "downloadLog");
   downloadLog.open (dLog.c_str ());
   downloadLog << "Segment_Index Download_Request_Sent Download_Start Download_End Segment_Size Download_OK\n";
   downloadLog.flush ();
 
-  std::string pLog = dashLogDirectory + m_algoName + "/" +  numberOfClients  + "/sim" + simulationId + "_" + "cl" + clientId + "_"  + "playbackLog.txt";
+  std::string pLog = LogFileName(simulationId, clientId, "playbackLog");
   playbackLog.open (pLog.c_str ());
   playbackLog << "Segment_Index Playback_Start Quality_Level\n";
   playbackLog.flush ();
 
-  std::string aLog = dashLogDirectory + m_algoName + "/" +  numberOfClients  + "/sim" + simulationId + "_" + "cl" + clientId + "_"  + "adaptationLog.txt";
+  std::string aLog = LogFileName(simulationId, clientId, "adaptationLog");
   adaptationLog.open (aLog.c_str ());
   adaptationLog << "Segment_Index Rep_Level Decision_Point_Of_Time Case DelayCase\n";
   adaptationLog.flush ();
 
-  std::string bLog = dashLogDirectory + m_algoName + "/" +  numberOfClients  + "/sim" + simulationId + "_" + "cl" + clientId + "_"  + "bufferLog.txt";
+  std::string bLog = LogFileName(simulationId, clientId, "bufferLog");
   bufferLog.open (bLog.c_str ());
   bufferLog << "     Time_Now  Buffer_Level \n";
   bufferLog.flush ();
 
-  std::string tLog = dashLogDirectory + m_algoName + "/" +  numberOfClients  + "/sim" + simulationId + "_" + "cl" + clientId + "_"  + "throughputLog.txt";
+  std::string tLog = LogFileName(simulationId, clientId, "throughputLog");
   throughputLog.open (tLog.c_str ());
   throughputLog << "     Time_Now Bytes Received \n";
   throughputLog.flush ();
 
-  std::string buLog = dashLogDirectory + m_algoName + "/" +  numberOfClients  + "/sim" + simulationId + "_" + "cl" + clientId + "_"  + "bufferUnderrunLog.txt";
+  std::string buLog = LogFileName(simulationId, clientId, "bufferUnderrunLog");
   bufferUnderrunLog.open (buLog.c_str ());
   bufferUnderrunLog << ("Buffer_Underrun_Started_At         Until \n");
   bufferUnderrunLog.flush ();

--- a/model/tcp-stream-client.h
+++ b/model/tcp-stream-client.h
@@ -251,6 +251,11 @@ private:
    */
   void InitializeLogFiles (std::string simulationId, std::string clientId, std::string numberOfClients);
 
+  /*
+   * \brief Get a file path for the given logging task
+   */
+  std::string LogFileName(const std::string& simId, const std::string& clientId, const std::string& logSuffix);
+
   uint32_t m_dataSize; //!< packet payload size
   uint8_t *m_data; //!< packet payload data
 


### PR DESCRIPTION
Adds a new script that can be used as a template against which to benchmark further changes to the repository to support QUIC/MP-QUIC/MP-TCP/etc.

Updates the logging folder structure to be a little more intuitive since we don't care too much about multiple clients at this stage.

I developed this using ns-3.30 since that is the latest version of ns-3 that is compatible with the given experimental implementation. I will likely migrate this to a more recent version of ns-3 (probably ns-3.34 or 3.35) at a later date.